### PR TITLE
added badblocks function

### DIFF
--- a/nodes/etherscan.go
+++ b/nodes/etherscan.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/eth"
 	"github.com/ethereum/go-ethereum/metrics"
 	"go.uber.org/ratelimit"
 )
@@ -26,6 +27,10 @@ func NewEtherscanHeaderCall(url, apiKey string) *etherscanMethodCaller {
 
 func (caller *etherscanMethodCaller) Version() (string, error) {
 	return "Not available", nil
+}
+
+func (caller *etherscanMethodCaller) GetBadBlocks() ([]*eth.BadBlockArgs, error) {
+	return []*eth.BadBlockArgs{}, nil
 }
 
 type jsonrpcMessage struct {

--- a/nodes/monitor.go
+++ b/nodes/monitor.go
@@ -236,17 +236,24 @@ func (mon *NodeMonitor) provideBadBlocks() {
 				var data []byte
 				// try to retrieve header from backend
 				if bl := mon.backend.get(block.Hash); bl != nil {
-					data, err = json.MarshalIndent(bl, "", " ")
+					type Header types.Header
+					data, err = json.MarshalIndent(struct {
+						Header
+						RLP string `json:"rlp"`
+					}{
+						Header: Header(*bl),
+						RLP:    block.RLP,
+					}, "", " ")
 					if err != nil {
-						log.Warn("Failed to marshall header", "error", err)
+						log.Warn("Failed to marshal header", "error", err)
 					}
 				}
 				if len(data) == 0 {
 					// block not found in backend, print what we know
 					type msBadBlockJSON struct {
-						Client string
-						Hash   common.Hash
-						RLP    string
+						Client string      `json:"client"`
+						Hash   common.Hash `json:"hash"`
+						RLP    string      `json:"rlp"`
 					}
 					b := msBadBlockJSON{
 						Client: block.Client,
@@ -255,7 +262,7 @@ func (mon *NodeMonitor) provideBadBlocks() {
 					}
 					data, err = json.MarshalIndent(b, "", " ")
 					if err != nil {
-						log.Warn("Failed to marshall header", "error", err)
+						log.Warn("Failed to marshal header", "error", err)
 						continue
 					}
 				}

--- a/nodes/monitor_test.go
+++ b/nodes/monitor_test.go
@@ -56,6 +56,10 @@ func (b brokenNode) LastProgress() int64 {
 	return 0
 }
 
+func (b brokenNode) BadBlocks() uint64 {
+	return 0
+}
+
 func newTestNode(id string, head int, chain []*blockInfo) *testNode {
 	return &testNode{
 		id,
@@ -103,6 +107,10 @@ func (t *testNode) HeadNum() uint64 {
 }
 
 func (t *testNode) LastProgress() int64 {
+	return 0
+}
+
+func (t *testNode) BadBlocks() uint64 {
 	return 0
 }
 

--- a/nodes/monitor_test.go
+++ b/nodes/monitor_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/eth"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -56,8 +57,8 @@ func (b brokenNode) LastProgress() int64 {
 	return 0
 }
 
-func (b brokenNode) BadBlocks() uint64 {
-	return 0
+func (b brokenNode) BadBlocks() []*eth.BadBlockArgs {
+	return []*eth.BadBlockArgs{}
 }
 
 func newTestNode(id string, head int, chain []*blockInfo) *testNode {
@@ -110,8 +111,8 @@ func (t *testNode) LastProgress() int64 {
 	return 0
 }
 
-func (t *testNode) BadBlocks() uint64 {
-	return 0
+func (t *testNode) BadBlocks() []*eth.BadBlockArgs {
+	return []*eth.BadBlockArgs{}
 }
 
 func TestMonitor(t *testing.T) {

--- a/nodes/nodes.go
+++ b/nodes/nodes.go
@@ -34,6 +34,7 @@ type Node interface {
 	BlockAt(num uint64, force bool) *blockInfo
 	HashAt(num uint64, force bool) common.Hash
 	HeadNum() uint64
+	BadBlocks() uint64
 }
 
 type clientJson struct {

--- a/nodes/nodes.go
+++ b/nodes/nodes.go
@@ -49,7 +49,7 @@ type clientJson struct {
 type badBlockJson struct {
 	Client string
 	Hash   common.Hash
-	RLP    string
+	RLP    string `json:"-"`
 }
 
 // Report represents one 'snapshot' of the state of the nodes, where they are at
@@ -64,9 +64,10 @@ type Report struct {
 
 func NewReport(headList []int) *Report {
 	return &Report{
-		Numbers: headList,
-		Cols:    nil,
-		Rows:    make(map[int][]string),
+		Numbers:   headList,
+		Cols:      nil,
+		Rows:      make(map[int][]string),
+		BadBlocks: make([]*badBlockJson, 0),
 	}
 }
 

--- a/nodes/nodes.go
+++ b/nodes/nodes.go
@@ -104,21 +104,8 @@ func (r *Report) Print() {
 }
 
 // AddToReport adds the given node to the report
-func (r *Report) AddToReport(node Node) {
-	var (
-		v, _      = node.Version()
-		badBlocks = node.BadBlocks()
-	)
-	// Add bad blocks to report
-	for _, block := range badBlocks {
-		r.BadBlocks = append(r.BadBlocks,
-			&badBlockJson{
-				Client: node.Name(),
-				Hash:   block.Hash,
-				RLP:    block.RLP,
-			},
-		)
-	}
+func (r *Report) AddToReport(node Node, badBlocks map[common.Hash]*badBlockJson) {
+	v, _ := node.Version()
 	// Add general node properties
 	r.Cols = append(r.Cols,
 		&clientJson{
@@ -129,6 +116,11 @@ func (r *Report) AddToReport(node Node) {
 			BadBlocks:    len(badBlocks),
 		},
 	)
+	// Add bad blocks
+	for _, block := range badBlocks {
+		r.BadBlocks = append(r.BadBlocks, block)
+	}
+	// Add hashes
 	for _, num := range r.Numbers {
 		row := r.Rows[num]
 		block := node.BlockAt(uint64(num), false)

--- a/nodes/rpcnode.go
+++ b/nodes/rpcnode.go
@@ -281,7 +281,7 @@ func (node *RemoteNode) HashAt(num uint64, force bool) common.Hash {
 func (node *RemoteNode) BadBlocks() []*eth.BadBlockArgs {
 	args, err := node.GetBadBlocks()
 	if err != nil {
-		return args
+		return []*eth.BadBlockArgs{}
 	}
-	return []*eth.BadBlockArgs{}
+	return args
 }

--- a/nodes/rpcnode.go
+++ b/nodes/rpcnode.go
@@ -278,10 +278,10 @@ func (node *RemoteNode) HashAt(num uint64, force bool) common.Hash {
 	return common.Hash{}
 }
 
-func (node *RemoteNode) BadBlocks() uint64 {
+func (node *RemoteNode) BadBlocks() []*eth.BadBlockArgs {
 	args, err := node.GetBadBlocks()
 	if err != nil {
-		return uint64(len(args))
+		return args
 	}
-	return 0
+	return []*eth.BadBlockArgs{}
 }

--- a/www/index.html
+++ b/www/index.html
@@ -63,9 +63,7 @@
         <table id="badblocks" class="table table-striped">
             <thead><tr>
                 <th>Client</th>
-                <th>BlockNumber</th>
                 <th>Hash</th>
-                <th>RLP</th>
             </tr></thead>
             <tbody></tbody>
         </table>

--- a/www/index.html
+++ b/www/index.html
@@ -43,6 +43,7 @@
                 <th>Version</th>
                 <th>Status</th>
                 <th>Last progress</th>
+                <th>BadBlocks</th>
             </tr></thead>
             <tbody></tbody>
         </table>

--- a/www/index.html
+++ b/www/index.html
@@ -59,6 +59,16 @@
             <thead></thead>
             <tbody></tbody>
         </table>
+        <h3>Bad Blocks</h3>
+        <table id="badblocks" class="table table-striped">
+            <thead><tr>
+                <th>Client</th>
+                <th>BlockNumber</th>
+                <th>Hash</th>
+                <th>RLP</th>
+            </tr></thead>
+            <tbody></tbody>
+        </table>
     </div>
     </body>
 </html>

--- a/www/script.js
+++ b/www/script.js
@@ -154,11 +154,15 @@ function onData(data){
         let version = client.Version
         let status = "OK"
         let progress = "Never"
+        let badblocks = "0"
         if (client.LastProgress > 0){
             progress = humanFriendly.timeSince(new Date(client.LastProgress*1000)) + " ago"
         }
         if (client.Status != 0) {
             status = " (unhealthy)"
+        }
+        if (client.BadBlocks > 0) {
+            badblocks = client.BadBlocks
         }
         let tRow = utils.tag("tr")
         tRow.append(utils.tag("td", name))

--- a/www/script.js
+++ b/www/script.js
@@ -34,7 +34,7 @@ let utils = {
     },
     etherscanLink : function(hash){
         let x = document.createElement("a");
-        x.setAttribute("href","https://etherscan.org/block/"+hash);
+        x.setAttribute("href","https://etherscan.io/block/"+hash);
         x.append("Etherscan")
         return x
     },
@@ -169,6 +169,7 @@ function onData(data){
         tRow.append(utils.tag("td", version))
         tRow.append(utils.tag("td", status))
         tRow.append(utils.tag("td", progress))
+        tRow.append(utils.tag("td", badblocks))
         nodeB.append(tRow)
         // Add td headings
         thead.append(utils.slantedHeading(name))
@@ -214,9 +215,23 @@ function onData(data){
         let tRow = utils.tag("tr")
         tRow.append(utils.tag("td", badblock.Client))
         tRow.append(utils.tag("td", utils.shortHash(badblock.Hash)))
-        tRow.append(utils.tag("td", badblock.RLP))
-        $(tRow).on('click', function(){showblock(badblock)})
+        $(tRow).on('click', function(){
+            showBadBlock(badblock.Client, badblock.Hash)
+        })
         badblocksB.append(tRow)
+    })
+}
+
+function showBadBlock(client, hash){
+    $.ajax("badblocks/"+hash+".json", {
+        dataType: "json",
+        success: function(data){
+            populateBlockInfo(data)
+        },
+        error: function(status, err){
+            populateBlockInfo({"hash": hash})
+            progress("Failed to fetch bad block: " + status.statusText + " error: " + err);
+            },
     })
 }
 

--- a/www/script.js
+++ b/www/script.js
@@ -206,6 +206,18 @@ function onData(data){
         }
         tbody.append(row)
     })
+
+    // Populate bad block info
+    var badblocksB = $("#badblocks tbody")
+    badblocksB.empty()
+    data.BadBlocks.forEach(function(badblock) {
+        let tRow = utils.tag("tr")
+        tRow.append(utils.tag("td", badblock.Client))
+        tRow.append(utils.tag("td", utils.shortHash(badblock.Hash)))
+        tRow.append(utils.tag("td", badblock.RLP))
+        $(tRow).on('click', function(){showblock(badblock)})
+        badblocksB.append(tRow)
+    })
 }
 
 


### PR DESCRIPTION
An initial implementation of bad blocks that queries the node for all bad blocks that occurred.
Edit: I made the node write bad blocks to `www/badblocks` which can then be queried from the frontend.
I also try to retrieve the header of the bad block from the database. If the bad block is not in our database, I'll return the RLP encoded block.

When block is in db:
![Screenshot_2020-10-15_14-05-47](https://user-images.githubusercontent.com/16664698/96121194-01332100-0ef0-11eb-81de-45e5fdfc9717.png)

When block is not in db:
![Screenshot_2020-10-15_14-07-32](https://user-images.githubusercontent.com/16664698/96121234-114b0080-0ef0-11eb-8966-4325583f3dca.png)
