### PR TITLE
etherscan: fix base10/16 error

### DIFF
--- a/nodes/api_test.go
+++ b/nodes/api_test.go
@@ -2,6 +2,7 @@ package nodes
 
 import (
 	"fmt"
+	"github.com/ethereum/go-ethereum/common"
 	"os"
 	"testing"
 )
@@ -52,4 +53,15 @@ func TestEtherscan(t *testing.T) {
 		t.Errorf("Got latest block 0")
 	}
 	t.Logf("Latest is %v", node.HeadNum())
+
+	got10 := node.HashAt(10, false)
+	want10 := common.HexToHash("0x4ff4a38b278ab49f7739d3a4ed4e12714386a9fdf72192f2e8f7da7822f10b4d")
+	if got10 != want10 {
+		want16 := common.HexToHash("0x9657beaf8542273d7448f6d277bb61aef0f700a91b238ac8b34c020f7fb8664c")
+		if got10 == want16 {
+			t.Errorf("error, base mismatch, requested block 10 but got block 16!")
+		} else {
+			t.Errorf("error: want %x, got %x", got10, want10)
+		}
+	}
 }

--- a/nodes/api_test.go
+++ b/nodes/api_test.go
@@ -2,9 +2,10 @@ package nodes
 
 import (
 	"fmt"
-	"github.com/ethereum/go-ethereum/common"
 	"os"
 	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
 )
 
 func TestInfura(t *testing.T) {

--- a/nodes/etherscan.go
+++ b/nodes/etherscan.go
@@ -38,7 +38,7 @@ type jsonrpcMessage struct {
 
 func (caller *etherscanMethodCaller) HeaderByNumber(num *big.Int) (*types.Header, error) {
 	action := "eth_getBlockByNumber"
-	tag := num.String()
+	tag := fmt.Sprintf("0x%x", num)
 	if num == nil {
 		tag = "latest"
 	}


### PR DESCRIPTION
Etherscan reported block `16` when we requested block `10`, because the number was just stringified