### PR TITLE
rpcnode: handle wrong returned headers

### DIFF
--- a/nodes/rpcnode.go
+++ b/nodes/rpcnode.go
@@ -226,6 +226,9 @@ func (node *RemoteNode) throttledGetHeader(num *big.Int) (*blockInfo, error) {
 		pHash: h.ParentHash,
 	}
 	node.chainHistory[bl.num] = bl
+	if num.Uint64() != bl.num {
+		return nil, fmt.Errorf("Remote node %v answered with wrong number, got %d, want %v", node.name, bl.num, num.Uint64())
+	}
 	return bl, nil
 }
 


### PR DESCRIPTION
Trying to shed some light on, and potentially fix (?)  https://github.com/holiman/nodemonitor/issues/8