### PR TITLE
update `.gitignore` to exclude `vendor/`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ blockDB
 config.toml
 www/hashes
 www/data.json
+vendor/


### PR DESCRIPTION
# Summary
Hey @holiman @karalabe 

- Update `.gitignore` to keep `vendor/` contents out of git (if vendoring isn't a thing for this project)