### PR TITLE
Add dark mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ FROM alpine:latest
 COPY --from=builder /nodemonitor/nodemonitor /usr/local/bin/
 
 ADD www/index.html /www/index.html
-ADD www/script.js /www/script.js
+ADD www/*.js /www/
 RUN mkdir -p /www/hashes
 RUN mkdir -p /www/vulns
 RUN mkdir -p /www/badblocks

--- a/www/color-mode.js
+++ b/www/color-mode.js
@@ -1,0 +1,78 @@
+/*!
+ Based on https://getbootstrap.com/docs/5.3/customize/color-modes/
+ */
+
+(() => {
+  'use strict'
+
+  const getStoredTheme = () => localStorage.getItem('theme')
+  const setStoredTheme = theme => localStorage.setItem('theme', theme)
+
+  const getPreferredTheme = () => {
+    const storedTheme = getStoredTheme()
+    if (storedTheme) {
+      return storedTheme
+    }
+
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+  }
+
+  const setTheme = theme => {
+    if (theme === 'auto' && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      document.documentElement.setAttribute('data-bs-theme', 'dark')
+    } else {
+      document.documentElement.setAttribute('data-bs-theme', theme)
+    }
+  }
+
+  setTheme(getPreferredTheme())
+
+  const showActiveTheme = (theme, focus = false) => {
+    const themeSwitcher = document.querySelector('#bd-theme')
+
+    if (!themeSwitcher) {
+      return
+    }
+
+    const themeSwitcherText = document.querySelector('#bd-theme-text')
+    const activeThemeIcon = document.querySelector('.theme-icon-active')
+    const btnToActive = document.querySelector(`[data-bs-theme-value="${theme}"]`)
+    const classOfActiveBtn = btnToActive.querySelector('i').getAttribute('class')
+
+    document.querySelectorAll('[data-bs-theme-value]').forEach(element => {
+      element.classList.remove('active')
+      element.setAttribute('aria-pressed', 'false')
+    })
+
+    btnToActive.classList.add('active')
+    btnToActive.setAttribute('aria-pressed', 'true')
+    activeThemeIcon.setAttribute('class', classOfActiveBtn + ' theme-icon-active')
+    const themeSwitcherLabel = `${themeSwitcherText.textContent} (${btnToActive.dataset.bsThemeValue})`
+    themeSwitcher.setAttribute('aria-label', themeSwitcherLabel)
+
+    if (focus) {
+      themeSwitcher.focus()
+    }
+  }
+
+  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+    const storedTheme = getStoredTheme()
+    if (storedTheme !== 'light' && storedTheme !== 'dark') {
+      setTheme(getPreferredTheme())
+    }
+  })
+
+  window.addEventListener('DOMContentLoaded', () => {
+    showActiveTheme(getPreferredTheme())
+
+    document.querySelectorAll('[data-bs-theme-value]')
+      .forEach(toggle => {
+        toggle.addEventListener('click', () => {
+          const theme = toggle.getAttribute('data-bs-theme-value')
+          setStoredTheme(theme)
+          setTheme(theme)
+          showActiveTheme(theme, true)
+        })
+      })
+  })
+})()

--- a/www/index.html
+++ b/www/index.html
@@ -7,14 +7,20 @@
         <title>Node monitor</title>
 
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css" integrity="sha512-NhSC1YmyruXifcj/KFRWoC561YpHpc5Jtzgvbuzx5VozKpWvQ+4nXhPdFgmx8xqexRcpAglTj9sIBWINXa8x5w==" crossorigin="anonymous" />
-        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.2/font/bootstrap-icons.min.css" integrity="sha384-GHL5aQs2BwQUg6AUEbqq6XFSN6lGo8DAT58V5NckuLm9Ibf0uR8i7T+GwodBqcET" crossorigin="anonymous">
         <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.min.js" integrity="sha512-bLT0Qm9VnAYZDflyKcBaQ2gg0hSYNQrJ8RilYldYQ1FxQYoCLtUjuuRuZo+fjqhx/qtq/1itJ0C2ejDxltZVFg==" crossorigin="anonymous"></script>
-        <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz" crossorigin="anonymous"></script>
         <style type="text/css">
+            .table>thead {
+                vertical-align: revert;
+            }
             th.rotate {
                 /* Something you can count on */
                 height: 140px;
                 white-space: nowrap;
+                background-color: transparent;
+                min-width: 60px;
             }
             th.rotate > div {
                 transform:
@@ -23,6 +29,7 @@
                             /* 45 is really 360 - 45 */
                         rotate(315deg);
                 width: 30px;
+                background-color: transparent;
             }
             th.rotate > div > span {
                 border-bottom: 1px solid #ccc;
@@ -30,16 +37,84 @@
             }
             #table td {
                 border-right: 1px solid #ddd;
+                background-color: inherit;
             }
 
+            [data-bs-theme=dark] #table tr.success {
+                background-color: rgb(0 260 60 / 5%)
+            }
+            [data-bs-theme=light] #table tr.success {
+                background-color: #dff0d8;
+            }
+            [data-bs-theme=dark] #table tr.danger {
+                background-color: rgb(255 0 0 / 5%);
+            }
+            [data-bs-theme=light] #table tr.danger {
+                background-color: #f2dede
+            }
+
+            #theme-button span{
+                margin-left: 10px;
+            }
+
+            #bdNavbar {
+                overflow: visible;
+                max-height: 40px;
+            }
+
+
+
         </style>
-        <script type="text/javascript" src="script.js"></script>
+
     </head>
-    <body>
+    <body class="mt-5">
+        <nav class="container-xxl bd-gutter flex-wrap flex-lg-nowrap" aria-label="Main navigation">
+            <div class="offcanvas-lg offcanvas-end flex-grow-1" tabindex="-1" id="bdNavbar" aria-labelledby="bdNavbarOffcanvasLabel" data-bs-scroll="true">
+              <div class="offcanvas-body p-4 pt-0 p-lg-0">
+                <hr class="d-lg-none text-white-50">
+
+                <ul class="navbar-nav flex-row flex-wrap ms-md-auto">
+                  <li class="nav-item dropdown" id="theme-button">
+                    <button style="float:right" class="btn btn-link nav-link py-2 px-0 px-lg-2 dropdown-toggle d-flex align-items-right"
+                            id="bd-theme"
+                            type="button"
+                            aria-expanded="false"
+                            data-bs-toggle="dropdown"
+                            data-bs-display="static"
+                            aria-label="Toggle theme (auto)">
+                      <i class="bi theme-icon-active"></i>
+                      <span class="d-lg-none ms-2" id="bd-theme-text">Toggle theme</span>
+                    </button>
+                    <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-theme-text">
+                      <li>
+                        <button type="button" class="dropdown-item d-flex align-items-center" data-bs-theme-value="light" aria-pressed="false">
+                          <i class="bi bi-sun-fill"></i>
+                          <span>Light</span>
+                        </button>
+                      </li>
+                      <li>
+                        <button type="button" class="dropdown-item d-flex align-items-center" data-bs-theme-value="dark" aria-pressed="false">
+                          <i class="bi bi-moon-stars-fill"></i>
+                          <span>Dark</span>
+                        </button>
+                      </li>
+                      <li>
+                        <button type="button" class="dropdown-item d-flex align-items-center active" data-bs-theme-value="auto" aria-pressed="true">
+
+                          <i class="bi bi-circle-half"></i>
+                          <span>Auto</span>
+                        </button>
+                      </li>
+                    </ul>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </nav>
         <!-- Modal -->
         <div class="modal fade" id="myModal" role="dialog">
           <div class="modal-dialog modal-lg">
-          
+
             <!-- Modal content-->
             <div class="modal-content">
               <div class="modal-header">
@@ -51,7 +126,7 @@
                 <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
               </div>
             </div>
-            
+
           </div>
         </div>
         <div class="container" role="main">
@@ -97,7 +172,8 @@
 </html>
 
 
-
+<script type="text/javascript" src="color-mode.js"></script>
+<script type="text/javascript" src="script.js"></script>
 <script type="text/javascript">
     function startTimer(display) {
         var display=$("#time")


### PR DESCRIPTION
This PR updates the bootstrap dependencies and includes dark mode. It's automatically detected based on the system settings and can be switched over via a dropdown menu on the top right. The user preference is persisted via local storage.

# Previews

## Dark

![image](https://github.com/ethereum/nodemonitor/assets/1500888/10a2d6e9-9e7b-4769-81f5-5ae018e3041e)

## Light 

![image](https://github.com/ethereum/nodemonitor/assets/1500888/f0dc386a-cfeb-42af-8627-b2d5057a42be)
